### PR TITLE
Update stride 4.1.0.1838

### DIFF
--- a/src/Samples/ControlCatalog/ControlCatalog.csproj
+++ b/src/Samples/ControlCatalog/ControlCatalog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Samples/TodoApp/TodoApp.csproj
+++ b/src/Samples/TodoApp/TodoApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.10.13" />

--- a/src/Samples/WindowsGame.Windows/WindowsGame.Windows.csproj
+++ b/src/Samples/WindowsGame.Windows/WindowsGame.Windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/WindowsGame/Views/ButtonWindow.axaml.cs
+++ b/src/Samples/WindowsGame/Views/ButtonWindow.axaml.cs
@@ -27,9 +27,7 @@ namespace WindowsGame.Views
             Random = random;
             WindowExtensions.SetRenderGroup(this, 31);
             this.InitializeComponent();
-#if DEBUG
-            this.AttachDevTools();
-#endif
+
             SetRandomSizePos();
         }
 

--- a/src/Samples/WindowsGame/Views/MainWindow.axaml.cs
+++ b/src/Samples/WindowsGame/Views/MainWindow.axaml.cs
@@ -14,9 +14,6 @@ namespace WindowsGame.Views
         public MainWindow()
         {
             InitializeComponent();
-#if DEBUG
-            this.AttachDevTools();
-#endif
         }
 
         private void InitializeComponent()

--- a/src/Samples/WindowsGame/WindowsGame.csproj
+++ b/src/Samples/WindowsGame/WindowsGame.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.10.13" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.13" />
     <PackageReference Include="ReactiveUI.Fody" Version="18.0.10" />
   </ItemGroup>

--- a/src/Samples/WindowsGame/WindowsGame.csproj
+++ b/src/Samples/WindowsGame/WindowsGame.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />

--- a/src/Stridelonia.Avalonia/Stridelonia.Avalonia.csproj
+++ b/src/Stridelonia.Avalonia/Stridelonia.Avalonia.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.10.13" />
-    <PackageReference Include="Stride.Core.Mathematics" Version="4.1.0.1459-beta" />
+    <PackageReference Include="Stride.Core.Mathematics" Version="4.1.0.1838" />
 
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Stridelonia.Avalonia/Stridelonia.Avalonia.csproj
+++ b/src/Stridelonia.Avalonia/Stridelonia.Avalonia.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Stridelonia.Samples.Windows/Stridelonia.Samples.Windows.csproj
+++ b/src/Stridelonia.Samples.Windows/Stridelonia.Samples.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>

--- a/src/Stridelonia.Samples/Stridelonia.Samples.csproj
+++ b/src/Stridelonia.Samples/Stridelonia.Samples.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stride.Engine" Version="4.1.0.1459-beta" />
-    <PackageReference Include="Stride.Video" Version="4.1.0.1459-beta" />
-    <PackageReference Include="Stride.Physics" Version="4.1.0.1459-beta" />
-    <PackageReference Include="Stride.Navigation" Version="4.1.0.1459-beta" />
-    <PackageReference Include="Stride.Particles" Version="4.1.0.1459-beta" />
-    <PackageReference Include="Stride.UI" Version="4.1.0.1459-beta" />
+    <PackageReference Include="Stride.Engine" Version="4.1.0.1838" />
+    <PackageReference Include="Stride.Video" Version="4.1.0.1838" />
+    <PackageReference Include="Stride.Physics" Version="4.1.0.1838" />
+    <PackageReference Include="Stride.Navigation" Version="4.1.0.1838" />
+    <PackageReference Include="Stride.Particles" Version="4.1.0.1838" />
+    <PackageReference Include="Stride.UI" Version="4.1.0.1838" />
 
-    <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.1.0.1459-beta" IncludeAssets="build;buildTransitive" />
+    <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.1.0.1838" IncludeAssets="build;buildTransitive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Stridelonia/Stridelonia.csproj
+++ b/src/Stridelonia/Stridelonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <StrideAssemblyProcessor>false</StrideAssemblyProcessor>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Stridelonia/Stridelonia.csproj
+++ b/src/Stridelonia/Stridelonia.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="Avalonia" Version="0.10.13" ExcludeAssets="build" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
 
-    <PackageReference Include="Stride.Engine" Version="4.1.0.1459-beta" PrivateAssets="contentfiles;analyzers" />
-    <PackageReference Include="Stride.Core" Version="4.1.0.1459-beta" PrivateAssets="contentfiles;analyzers" />
-    <PackageReference Include="Stride.UI" Version="4.1.0.1459-beta" />
+    <PackageReference Include="Stride.Engine" Version="4.1.0.1838" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Core" Version="4.1.0.1838" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.UI" Version="4.1.0.1838" />
 
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
 - Updated to .NET 6
 - Updated Stride package references
 - removed Avalonia.Diagnostics package due to conflict with Microsoft.CodeAnalysis.Common 3.4.0 in avalonia 10 and Microsoft.CodeAnalysis.Common 3.6.0 in Stride 4.1.0.1838